### PR TITLE
Repeat observations per object + constellation/satellite types

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -830,6 +830,8 @@ app.post('/api/celestial-objects', async (req, res) => {
         'star_cluster': 'https://images.unsplash.com/photo-1419242902214-272b3f66ee7a?auto=format&fit=crop&w=800&h=500',
         'planet': 'https://images.unsplash.com/photo-1614728263952-84ea256f9679?auto=format&fit=crop&w=800&h=500',
         'double_star': 'https://images.unsplash.com/photo-1502134249126-9f3755a50d78?auto=format&fit=crop&w=800&h=500',
+        'constellation': 'https://images.unsplash.com/photo-1419242902214-272b3f66ee7a?auto=format&fit=crop&w=800&h=500',
+        'satellite': 'https://images.unsplash.com/photo-1534447677768-be436bb09401?auto=format&fit=crop&w=800&h=500',
         'other': 'https://images.unsplash.com/photo-1534447677768-be436bb09401?auto=format&fit=crop&w=800&h=500',
       };
       imageUrl = fallbackImages[objectType.toLowerCase()] || fallbackImages['galaxy'];

--- a/client/src/components/astronomy/AddObservationDialog.tsx
+++ b/client/src/components/astronomy/AddObservationDialog.tsx
@@ -90,9 +90,17 @@ const AddObservationDialog: React.FC<AddObservationDialogProps> = ({ open, onOpe
     },
   });
   
-  // Filter out objects that are already in the observation list
-  const availableObjects = (celestialObjects as CelestialObject[]).filter((obj: CelestialObject) => 
-    !(observations as any[]).some((obs: any) => obs.objectId === obj.id)
+  // Count how many times each object has already been observed (to hint in the picker)
+  const observedCountByObjectId = (observations as any[]).reduce((acc: Record<number, number>, obs: any) => {
+    if (obs.isObserved && obs.objectId != null) {
+      acc[obs.objectId] = (acc[obs.objectId] || 0) + 1;
+    }
+    return acc;
+  }, {} as Record<number, number>);
+
+  // Show ALL catalog objects so the same object can be logged multiple times
+  const availableObjects = [...(celestialObjects as CelestialObject[])].sort((a, b) =>
+    a.name.localeCompare(b.name)
   );
   
   // Handle object selection from search
@@ -177,29 +185,16 @@ const AddObservationDialog: React.FC<AddObservationDialogProps> = ({ open, onOpe
   });
 
   const onSubmit = (values: FormValues) => {
-    // Check for duplicate if selecting existing object
-    if (values.selectedObjectId) {
-      const isDuplicate = (observations as any[]).some((obs: any) => obs.objectId === values.selectedObjectId);
-      if (isDuplicate) {
-        toast({
-          title: 'Object already in list',
-          description: 'This object is already in your observation list.',
-          variant: 'destructive',
-        });
-        return;
-      }
-    } else {
-      // When creating new object, validate object type is provided
-      if (!values.objectType) {
-        toast({
-          title: 'Object type required',
-          description: 'Please select an object type when creating a new object.',
-          variant: 'destructive',
-        });
-        return;
-      }
+    // When creating a new custom object, an object type is required
+    if (!values.selectedObjectId && !values.objectType) {
+      toast({
+        title: 'Object type required',
+        description: 'Please select an object type when creating a new object.',
+        variant: 'destructive',
+      });
+      return;
     }
-    
+
     addObservationMutation.mutate(values);
   };
 
@@ -314,6 +309,7 @@ const AddObservationDialog: React.FC<AddObservationDialogProps> = ({ open, onOpe
                                     <span className="font-medium">{obj.name}</span>
                                     <span className="text-xs text-star-dim">
                                       {obj.type.replace('_', ' ').replace(/\b\w/g, (c: string) => c.toUpperCase())}
+                                      {observedCountByObjectId[obj.id] ? ` · observed ${observedCountByObjectId[obj.id]}×` : ''}
                                     </span>
                                   </div>
                                 </CommandItem>

--- a/client/src/components/astronomy/CelestialCard.tsx
+++ b/client/src/components/astronomy/CelestialCard.tsx
@@ -33,6 +33,10 @@ const CelestialCard = ({
         return <i className="fas fa-star-half-alt text-stellar-gold mr-1"></i>;
       case 'moon':
         return <i className="fas fa-moon text-stellar-gold mr-1"></i>;
+      case 'satellite':
+        return <i className="fas fa-satellite text-stellar-gold mr-1"></i>;
+      case 'constellation':
+        return <i className="fas fa-star text-stellar-gold mr-1"></i>;
       default:
         return <i className="fas fa-star text-stellar-gold mr-1"></i>;
     }
@@ -61,6 +65,10 @@ const CelestialCard = ({
         return 'https://images.unsplash.com/photo-1502134249126-9f3755a50d78?w=800&h=500&fit=crop&auto=format'; // Double star image
       case 'moon':
         return 'https://images.unsplash.com/photo-1446776877081-d282a0f896e2?w=800&h=500&fit=crop&auto=format'; // Moon image
+      case 'constellation':
+        return 'https://images.unsplash.com/photo-1593331292296-1bb2644113cb?w=800&h=500&fit=crop&auto=format'; // Constellation / starfield image
+      case 'satellite':
+        return 'https://images.unsplash.com/photo-1446776877081-d282a0f896e2?w=800&h=500&fit=crop&auto=format'; // Satellite / space image
       default:
         return 'https://images.unsplash.com/photo-1462331940025-496dfbfc7564?w=800&h=500&fit=crop&auto=format'; // Generic space image
     }

--- a/client/src/pages/MyObservations.tsx
+++ b/client/src/pages/MyObservations.tsx
@@ -31,6 +31,10 @@ const MyObservations = () => {
         return 'https://images.unsplash.com/photo-1502134249126-9f3755a50d78?w=800&h=500&fit=crop&auto=format';
       case 'moon':
         return 'https://images.unsplash.com/photo-1446776877081-d282a0f896e2?w=800&h=500&fit=crop&auto=format';
+      case 'constellation':
+        return 'https://images.unsplash.com/photo-1593331292296-1bb2644113cb?w=800&h=500&fit=crop&auto=format';
+      case 'satellite':
+        return 'https://images.unsplash.com/photo-1446776877081-d282a0f896e2?w=800&h=500&fit=crop&auto=format';
       default:
         return 'https://images.unsplash.com/photo-1462331940025-496dfbfc7564?w=800&h=500&fit=crop&auto=format';
     }
@@ -188,9 +192,33 @@ const MyObservations = () => {
     return dateStr ? new Date(dateStr).getTime() : 0;
   };
 
-  const observedSorted = (observations || [])
-    .filter(obs => obs.isObserved)
-    .sort((a, b) => getObservationSortDate(b) - getObservationSortDate(a));
+  // Format an observation's date for display (adjusts for PST timezone)
+  const formatObservedDate = (obs: EnhancedObservation) => {
+    if (obs.plannedDate) {
+      const date = new Date(obs.plannedDate);
+      const userTimezoneDate = new Date(date.getTime() + (480 * 60000)); // Add 8 hours for PST
+      return userTimezoneDate.toLocaleDateString();
+    }
+    return obs.dateAdded ? new Date(obs.dateAdded as Date).toLocaleDateString() : 'Unknown';
+  };
+
+  // Group observed entries by object so the same object seen multiple times shows
+  // once with a total count and all of its dated sessions nested inside
+  const observedGroups = (() => {
+    const groups = new Map<number, { object: any; sessions: EnhancedObservation[] }>();
+    for (const obs of (observations || []).filter(obs => obs.isObserved)) {
+      const key = obs.objectId ?? -1;
+      if (!groups.has(key)) {
+        groups.set(key, { object: obs.celestialObject, sessions: [] });
+      }
+      groups.get(key)!.sessions.push(obs);
+    }
+    const arr = Array.from(groups.values());
+    // Newest session first within each group, and groups ordered by most recent session
+    arr.forEach(g => g.sessions.sort((a, b) => getObservationSortDate(b) - getObservationSortDate(a)));
+    arr.sort((a, b) => getObservationSortDate(b.sessions[0]) - getObservationSortDate(a.sessions[0]));
+    return arr;
+  })();
 
   return (
     <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-12 pt-8">
@@ -310,8 +338,11 @@ const MyObservations = () => {
                                   observation.celestialObject?.type === 'nebula' ? 'meteor' : 
                                   observation.celestialObject?.type === 'planet' ? 'globe' : 
                                   observation.celestialObject?.type === 'star_cluster' ? 'star' :
+                                  observation.celestialObject?.type === 'double_star' ? 'star-half-alt' :
+                                  observation.celestialObject?.type === 'moon' ? 'moon' :
+                                  observation.celestialObject?.type === 'satellite' ? 'satellite' :
                                   'star'
-                                } mr-1`}></i> 
+                                } mr-1`}></i>
                                 {observation.celestialObject?.type.replace('_', ' ').replace(/\b\w/g, (c: string) => c.toUpperCase())}
                               </span>
                               <span className="flex items-center">
@@ -354,112 +385,110 @@ const MyObservations = () => {
                 </div>
               )}
 
-              {/* Observed Entries Section */}
-              {observedSorted.length > 0 && (
+              {/* Observed Entries Section - grouped by object with a total count */}
+              {observedGroups.length > 0 && (
                 <div className="mb-8">
                   <h3 className="text-xl text-space font-bold mb-4 flex items-center">
                     <span className="inline-block w-3 h-3 rounded-full bg-green-300 mr-2"></span>
                     Observed Entries
                   </h3>
                   <div className="space-y-6">
-                    {observedSorted.map(observation => (
-                      <div key={observation.id} className="bg-space-blue-light rounded-lg p-6 flex flex-col gap-4">
-                        <div className="flex flex-col md:flex-row gap-4">
-                          <img 
-                            src={observation.celestialObject?.imageUrl || getTypeSpecificFallbackImage(observation.celestialObject?.type || 'other')} 
-                            alt={observation.celestialObject?.name} 
-                            className="w-20 h-20 rounded-md object-cover" 
+                    {observedGroups.map(group => (
+                      <div key={group.object?.id ?? group.sessions[0].id} className="bg-space-blue-light rounded-lg p-6 flex flex-col gap-4">
+                        {/* Object header with count */}
+                        <div className="flex gap-4">
+                          <img
+                            src={group.object?.imageUrl || getTypeSpecificFallbackImage(group.object?.type || 'other')}
+                            alt={group.object?.name}
+                            className="w-20 h-20 rounded-md object-cover shrink-0"
                             onError={(e) => {
                               const target = e.target as HTMLImageElement;
                               target.onerror = null;
-                              target.src = getTypeSpecificFallbackImage(observation.celestialObject?.type || 'other');
+                              target.src = getTypeSpecificFallbackImage(group.object?.type || 'other');
                             }}
                           />
-                          <div className="flex-1">
-                            <div className="flex justify-between items-start">
-                              <h4 className="text-space font-semibold text-xl">{observation.celestialObject?.name}</h4>
-                              <div className="flex items-center space-x-2">
-                                <Button 
-                                  variant="ghost"
-                                  className="text-green-300 hover:text-green-200"
-                                  onClick={() => handleToggleObserved(observation.id, observation.isObserved!)}
-                                  title="Mark as not observed"
-                                >
-                                  <i className="fas fa-check-circle text-xl"></i>
-                                </Button>
-                                <Button 
-                                  variant="ghost"
-                                  className="text-star-dim hover:text-stellar-gold"
-                                  onClick={() => handleOpenNotesDialog(observation)}
-                                  title="Edit notes"
-                                >
-                                  <i className="fas fa-edit text-xl"></i>
-                                </Button>
-                                <Button 
-                                  variant="ghost"
-                                  className="text-star-dim hover:text-red-500"
-                                  onClick={() => handleRemove(observation.id)}
-                                  title="Remove from observation list"
-                                >
-                                  <i className="fas fa-trash text-xl"></i>
-                                </Button>
-
+                          <div className="flex-1 min-w-0">
+                            <div className="flex justify-between items-start gap-3">
+                              <div>
+                                <h4 className="text-space font-semibold text-xl">{group.object?.name}</h4>
+                                <span className="text-sm text-star-dim">
+                                  <i className={`fas fa-${
+                                    group.object?.type === 'galaxy' ? 'galaxy' :
+                                    group.object?.type === 'nebula' ? 'meteor' :
+                                    group.object?.type === 'planet' ? 'globe' :
+                                    group.object?.type === 'star_cluster' ? 'star' :
+                                    group.object?.type === 'double_star' ? 'star-half-alt' :
+                                    group.object?.type === 'moon' ? 'moon' :
+                                    group.object?.type === 'satellite' ? 'satellite' :
+                                    'star'
+                                  } mr-1`}></i>
+                                  {(group.object?.type || 'other').replace('_', ' ').replace(/\b\w/g, (c: string) => c.toUpperCase())}
+                                </span>
                               </div>
-                            </div>
-                            <div className="flex flex-wrap items-center gap-x-4 gap-y-1 my-1 text-sm text-star-dim">
-                              <span>
-                                <i className={`fas fa-${
-                                  observation.celestialObject?.type === 'galaxy' ? 'galaxy' : 
-                                  observation.celestialObject?.type === 'nebula' ? 'meteor' : 
-                                  observation.celestialObject?.type === 'planet' ? 'globe' : 
-                                  observation.celestialObject?.type === 'star_cluster' ? 'star' :
-                                  'star'
-                                } mr-1`}></i> 
-                                {observation.celestialObject?.type.replace('_', ' ').replace(/\b\w/g, (c: string) => c.toUpperCase())}
-                              </span>
-                              <span className="flex items-center">
-                                <i className="fas fa-calendar mr-1"></i> 
-                                Observed: {observation.plannedDate ? 
-                                  (() => {
-                                    const date = new Date(observation.plannedDate);
-                                    // Adjust for PST timezone (UTC-8)
-                                    const userTimezoneDate = new Date(date.getTime() + (480 * 60000));
-                                    return userTimezoneDate.toLocaleDateString();
-                                  })() : 
-                                  (observation.dateAdded ? new Date(observation.dateAdded as Date).toLocaleDateString() : 'Unknown')}
-                                <Button
-                                  variant="ghost"
-                                  className="ml-1 p-1 h-auto text-star-dim hover:text-stellar-gold"
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    handleOpenDateDialog(observation);
-                                  }}
-                                  title="Edit observation date"
-                                >
-                                  <i className="fas fa-pencil-alt text-xs"></i>
-                                </Button>
+                              <span className="inline-flex items-center gap-1 bg-space-blue-dark text-green-300 text-sm font-medium px-3 py-1 rounded-full whitespace-nowrap">
+                                <i className="fas fa-check-circle"></i> Observed {group.sessions.length}×
                               </span>
                             </div>
                           </div>
                         </div>
-                        
-                        {/* Journal-style notes display */}
-                        <div className="mt-2">
-                          {observation.observationNotes ? (
-                            <div className="bg-space-blue-dark rounded-lg p-4 text-star-white">
-                              <h5 className="text-nebula-pink text-sm font-medium mb-2 flex items-center">
-                                <i className="fas fa-sticky-note mr-2"></i> Observation Notes
-                              </h5>
-                              <p className="whitespace-pre-line text-sm">{observation.observationNotes}</p>
+
+                        {/* Dated sessions */}
+                        <div className="space-y-3">
+                          {group.sessions.map(session => (
+                            <div key={session.id} className="bg-space-blue-dark rounded-lg p-4">
+                              <div className="flex justify-between items-start gap-3">
+                                <div className="flex items-center text-sm text-star-dim">
+                                  <i className="fas fa-calendar mr-2"></i>
+                                  {formatObservedDate(session)}
+                                  <Button
+                                    variant="ghost"
+                                    className="ml-1 p-1 h-auto text-star-dim hover:text-stellar-gold"
+                                    onClick={() => handleOpenDateDialog(session)}
+                                    title="Edit observation date"
+                                  >
+                                    <i className="fas fa-pencil-alt text-xs"></i>
+                                  </Button>
+                                </div>
+                                <div className="flex items-center space-x-1 shrink-0">
+                                  <Button
+                                    variant="ghost"
+                                    className="text-star-dim hover:text-stellar-gold"
+                                    onClick={() => handleOpenNotesDialog(session)}
+                                    title="Edit notes"
+                                  >
+                                    <i className="fas fa-edit"></i>
+                                  </Button>
+                                  <Button
+                                    variant="ghost"
+                                    className="text-green-300 hover:text-yellow-400"
+                                    onClick={() => handleToggleObserved(session.id, session.isObserved!)}
+                                    title="Mark as not observed"
+                                  >
+                                    <i className="fas fa-check-circle"></i>
+                                  </Button>
+                                  <Button
+                                    variant="ghost"
+                                    className="text-star-dim hover:text-red-500"
+                                    onClick={() => handleRemove(session.id)}
+                                    title="Remove this observation"
+                                  >
+                                    <i className="fas fa-trash"></i>
+                                  </Button>
+                                </div>
+                              </div>
+                              {session.observationNotes ? (
+                                <p className="whitespace-pre-line text-sm text-star-white mt-2">{session.observationNotes}</p>
+                              ) : (
+                                <button
+                                  type="button"
+                                  className="text-star-dim text-sm mt-2 hover:text-stellar-gold"
+                                  onClick={() => handleOpenNotesDialog(session)}
+                                >
+                                  <i className="fas fa-plus-circle mr-1"></i> Add notes
+                                </button>
+                              )}
                             </div>
-                          ) : (
-                            <div className="border border-dashed border-cosmic-purple rounded-lg p-4 text-center cursor-pointer" 
-                                 onClick={() => handleOpenNotesDialog(observation)}>
-                              <p className="text-star-dim">
-                                <i className="fas fa-plus-circle mr-1"></i> Add your observation notes
-                              </p>
-                            </div>
-                          )}
+                          ))}
                         </div>
                       </div>
                     ))}

--- a/server/services/celestialObjects.ts
+++ b/server/services/celestialObjects.ts
@@ -216,6 +216,10 @@ export function getTypeSpecificFallbackImage(type: string): string {
       return 'https://images.unsplash.com/photo-1502134249126-9f3755a50d78?w=800&h=500&fit=crop';
     case 'moon':
       return 'https://images.unsplash.com/photo-1446776877081-d282a0f896e2?w=800&h=500&fit=crop';
+    case 'constellation':
+      return 'https://images.unsplash.com/photo-1419242902214-272b3f66ee7a?w=800&h=500&fit=crop';
+    case 'satellite':
+      return 'https://images.unsplash.com/photo-1534447677768-be436bb09401?w=800&h=500&fit=crop';
     default:
       return 'https://images.unsplash.com/photo-1462331940025-496dfbfc7564?w=800&h=500&fit=crop';
   }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -15,7 +15,7 @@ export const insertUserSchema = createInsertSchema(users).pick({
 });
 
 // Define celestial object types
-export const celestialObjectTypes = ["planet", "galaxy", "nebula", "star_cluster", "double_star", "moon", "other"] as const;
+export const celestialObjectTypes = ["planet", "galaxy", "nebula", "star_cluster", "double_star", "moon", "constellation", "satellite", "other"] as const;
 export type CelestialObjectType = typeof celestialObjectTypes[number];
 
 // Celestial objects schema (static catalog - object info that doesn't change)


### PR DESCRIPTION
## What

Two changes to the observation journal, both verified on the local dev server:

### 1. Log the same object multiple times
- Previously you could only ever add an object once — the Add Entry picker hid already-observed objects and rejected duplicates.
- Now the picker shows **all** catalog objects (with an `observed N×` hint), so you can re-log Jupiter, a constellation you're monitoring, etc.
- The **Observed** section is now **grouped by object**: one card per object with an `Observed N×` badge and each dated session (date + notes) nested inside, each keeping its own edit / remove / mark-unobserved controls.
- Backend already supported multiple rows per `objectId` — no schema migration.

### 2. New object types: `constellation` and `satellite`
- Added to `celestialObjectTypes`, so they appear in the type dropdown automatically.
- Wired through create-object image fallbacks (Vercel `api/index.ts` + local `server/services/celestialObjects.ts`) and the type icon/image maps (`MyObservations`, `CelestialCard`).
- Lets targets like **Corona Borealis** (constellation) or a **Starlink** train (satellite) be categorized properly instead of "Other". Satellite gets a 🛰 `fa-satellite` icon.

## Notes
- `npm run check` (tsc) and `npm run build:vercel` both pass.
- Existing entries already filed as "Other" are not auto-reclassified.
- `My Progress` heatmap needs no changes; "Total Observed" now counts sessions (matches the "N×" framing), while Planets/Messier still dedupe by object.

## Test plan
- Add Entry → pick an already-observed object → mark observed + date → card shows `Observed 2×` with both nights.
- Add Entry → Create new object → type **Constellation**/**Satellite** now selectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)